### PR TITLE
fix artifact symlink error

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -14,11 +14,17 @@ steps:
     - bin/ci/verify_a_plan.ps1 -Plan ruby-plus-devkit
   expeditor:
     executor:
-      windows:
+      docker:
+        host_os: windows
+        shell: [ "powershell", "-Command" ]
+
 
 - label: ":windows: :ruby: ruby27-plus-devkit plan"
   commands:
     - bin/ci/verify_a_plan.ps1 -Plan ruby27-plus-devkit
   expeditor:
     executor:
-      windows:
+      docker:
+        host_os: windows
+        shell: [ "powershell", "-Command" ]
+

--- a/bin/ci/verify_a_plan.ps1
+++ b/bin/ci/verify_a_plan.ps1
@@ -8,7 +8,7 @@ param (
     [ValidateNotNullorEmpty()]
     [string]$Plan
 )
-
+$env:HAB_LICENSE = "accept-no-persist"
 $env:HAB_ORIGIN = 'ci'
 
 Write-Host "--- :8ball: :windows: Verifying $Plan"


### PR DESCRIPTION
Verify pipeline is still broken downloading the devkit, but this at least fixes the hab studio blowup trying to symlink a non-existent artifact cache by using a docker environment which it really should be doing anyways.

Signed-off-by: mwrock <matt@mattwrock.com>
