### PR TITLE
Revert "Try to download from S3 (#5)"

### DIFF
--- a/ruby-plus-devkit/plan.ps1
+++ b/ruby-plus-devkit/plan.ps1
@@ -4,7 +4,7 @@ $pkg_version="2.6.5"
 $pkg_revision="1"
 $pkg_maintainer="maintainers@chef.io"
 $pkg_license=@("Apache-2.0")
-$pkg_source="https://public-cd-buildkite-cache.s3-us-west-2.amazonaws.com/rubyinstaller-devkit-${pkg_version}-${pkg_revision}-x64.exe"
+$pkg_source="https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-${pkg_version}-${pkg_revision}/rubyinstaller-devkit-${pkg_version}-${pkg_revision}-x64.exe"
 $pkg_shasum="BD2050496A149C7258ED4E2E44103756CA3A05C7328A939F0FDC97AE9616A96D"
 $pkg_bin_dirs=@(
     "bin"

--- a/ruby27-plus-devkit/plan.ps1
+++ b/ruby27-plus-devkit/plan.ps1
@@ -4,7 +4,7 @@ $pkg_version="2.7.0"
 $pkg_revision="1"
 $pkg_maintainer="maintainers@chef.io"
 $pkg_license=@("Apache-2.0")
-$pkg_source="https://public-cd-buildkite-cache.s3-us-west-2.amazonaws.com/rubyinstaller-devkit-${pkg_version}-${pkg_revision}-x64.exe"
+$pkg_source="https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-${pkg_version}-${pkg_revision}/rubyinstaller-devkit-${pkg_version}-${pkg_revision}-x64.exe"
 $pkg_shasum="af72cdb6afe2f5e04cb58bb11234c0d3d107d449482141b72dd8430a2ed1fe98"
 $pkg_bin_dirs=@(
     "bin"


### PR DESCRIPTION
This reverts commit 1dc766ab56dda2f6457c4bc0f998330d72f6dd9c.

Move back to pull binaries directly from `oneclick/rubyinstaller2` GitHub releases. We should not hit any sort of cache limits and manually storing the files in an S3 bucket creates a maintenance burden. 