### PR TITLE
fail verify if pester has failures

### DIFF
--- a/bin/ci/verify_a_plan.ps1
+++ b/bin/ci/verify_a_plan.ps1
@@ -46,6 +46,9 @@ try {
 
   Write-Host "--- :mag_right: Testing $Plan"
   powershell -File "./${Plan}/tests/test.ps1" -PackageIdentifier $pkg_ident
+  $status = $LASTEXITCODE
 } finally {
     Pop-Location
 }
+
+exit $status


### PR DESCRIPTION
I noticed that a PR was reporting success when it had a pester failure. Looks like we are not exiting with the exit code from the pester tests.

Signed-off-by: mwrock <matt@mattwrock.com>
