### PR TITLE
bump ruby-plus-devkit to revision 2

### DIFF
--- a/ruby-plus-devkit/plan.ps1
+++ b/ruby-plus-devkit/plan.ps1
@@ -1,31 +1,19 @@
 $pkg_name="ruby-plus-devkit"
 $pkg_origin="chef"
 $pkg_version="2.6.6"
-$pkg_revision="1"
+$pkg_revision="2"
 $pkg_description="A repackaging of RubyInstaller2 and its MSYS2-based DevKit."
 $pkg_maintainer="The Chef Maintainers <maintainers@chef.io>"
 $pkg_upstream_url="https://github.com/chef/chef-plans"
 $pkg_license=@("Apache-2.0")
 $pkg_source="https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-${pkg_version}-${pkg_revision}/rubyinstaller-devkit-${pkg_version}-${pkg_revision}-x64.exe"
-$pkg_shasum="6381fa0c683d4b9f8ceedaa6b8b1191a0c4029588f11f8c77979f6e2cc00dd98"
+$pkg_shasum="678fb941c75bdc0fed902e78d5e984410c0b166a53cd3a0b036046ceace91f47"
 $pkg_bin_dirs=@(
     "bin"
     "/msys64/mingw64/bin"
     "/msys64/usr/bin"
 )
 $ruby_abi_version = [RegEx]::Replace($pkg_version, "\.\d+$", ".0")
-
-function Invoke-Begin {
-    $hab_version = (hab --version)
-    $hab_minor_version = $hab_version.split('.')[1]
-    if ( -not $? -Or $hab_minor_version -lt 85 ) {
-        Write-Warning "(╯°□°）╯︵ ┻━┻ I CAN'T WORK UNDER THESE CONDITIONS!"
-        Write-Warning ":habicat: I'm being built with $hab_version. I need at least Hab 0.85.0, because I use the -IsPath option for setting/pushing paths in SetupEnvironment."
-        throw "unable to build: required minimum version of Habitat not installed"
-    } else {
-        Write-BuildLine ":habicat: I think I have the version I need to build."
-    }
-}
 
 function Invoke-SetupEnvironment {
     Push-RuntimeEnv -IsPath "GEM_PATH" "$pkg_prefix/lib/ruby/gems/$ruby_abi_version"
@@ -38,7 +26,7 @@ function Invoke-Unpack {
 
 function Invoke-Build {
     Write-BuildLine "** Launch msys2 once in order to initialize the install"
-    Invoke-Expression -Command "$HAB_CACHE_SRC_PATH/$pkg_dirname/msys64/msys2_shell.cmd -defterm -no-start" -Verbose
+    Start-Process "$HAB_CACHE_SRC_PATH/$pkg_dirname/msys64/msys2_shell.cmd" -ArgumentList "-defterm -no-start"
     # The path separator in the -ILike value below must be a backslash for it will match properly
     Get-Process | Where-Object Path -ILike "$HAB_CACHE_SRC_PATH\$pkg_dirname\*" | Stop-Process -Force
 }


### PR DESCRIPTION
This will fix the chef-15 habitat builds. Revision 2 included git which was missing in 1.

This also:
* Removes the version check. I think `0.85` is sufficiently old enough that we don't need to worry about it being on a CI builder. Also, the logic was breaking the build.
*  Fixes an issue where initializing the shell was hanging on a UI prompt

Signed-off-by: Matt Wrock <matt@mattwrock.com>
