### PR TITLE
Updating expeditor configurations

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -12,19 +12,18 @@ pipelines:
       public: true
   - habitat/build
 
-promote:
-  channels:
-    - unstable
-    - stable
-
-# These actions are taken, in order they are specified, anytime a Pull Request is merged.
-merge_actions:
-  - trigger_pipeline:habitat/build:
-      ignore_labels:
-        - "Expeditor: Skip Habitat"
-        - "Expeditor: Skip All"
+artifact_channels:
+  - unstable
+  - stable
 
 subscriptions:
   - workload: project_promoted:{{agent_id}}:*
     actions:
       - built_in:promote_habitat_packages
+  # These actions are taken, in order they are specified, anytime a Pull Request is merged.
+  - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
+    actions:
+      - trigger_pipeline:habitat/build:
+          ignore_labels:
+            - "Expeditor: Skip Habitat"
+            - "Expeditor: Skip All"


### PR DESCRIPTION
Signed-off-by: Swati Keshari <skeshari@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
The merge_actions subscription shortcut has been deprecated. All subscriptions should be declared via the subscriptions block for clarity. 
The promote configuration block has been deprecated for clarity. Artifact channels are relevant to things beyond promotions. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
