### PR TITLE
ruby33-plus-devkit added for Inspec[CHEF-11397]

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -33,3 +33,9 @@ build_targets = [
   "x86_64-windows"
 ]
 plan_path = "ruby32-plus-devkit"
+
+[ruby33-plus-devkit]
+build_targets = [
+  "x86_64-windows"
+]
+plan_path = "ruby33-plus-devkit"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -62,3 +62,12 @@ steps:
       docker:
         host_os: windows
         shell: [ "powershell", "-Command" ]
+        
+  label: ":windows: :ruby: ruby33-plus-devkit plan"
+  commands:
+    - bin/ci/verify_a_plan.ps1 -Plan ruby33-plus-devkit
+  expeditor:
+    executor:
+      docker:
+        host_os: windows
+        shell: [ "powershell", "-Command" ]

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -63,7 +63,7 @@ steps:
         host_os: windows
         shell: [ "powershell", "-Command" ]
         
-  label: ":windows: :ruby: ruby33-plus-devkit plan"
+- label: ":windows: :ruby: ruby33-plus-devkit plan"
   commands:
     - bin/ci/verify_a_plan.ps1 -Plan ruby33-plus-devkit
   expeditor:

--- a/ruby33-plus-devkit/README.md
+++ b/ruby33-plus-devkit/README.md
@@ -1,0 +1,26 @@
+# Habitat package: ruby33-plus-devkit
+
+This is a repackaging of the MSYS2 based RubyInstaller2 for Windows. Packages produced with this plan will include the MSYS2/UCRT64 "DevKit" to provide libraries and binaries that the Ruby ecosystem tends to rely upon.
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+This package provides binaries and libraries specifically for consumption by Ruby-based projects from Chef Software. No support should be expected for direct use of this package by other projects.
+
+For Chef projects on Windows:
+
+* Add this to your package's runtime dependencies. `$pkg_deps=@("chef/ruby33-plus-devkit")`
+* Your package likely installs gems it requires. Those gems should be installed them to a directory within your project. Push that package-internal directory onto GEM_PATH.
+
+## Testing
+
+Build the package and run tests, from this plan directory:
+
+```
+hab pkg build .
+. results/last_build.ps1
+./test.ps1 -PackageIdentifier $pkg_ident
+```

--- a/ruby33-plus-devkit/plan.ps1
+++ b/ruby33-plus-devkit/plan.ps1
@@ -1,0 +1,51 @@
+$pkg_name="ruby33-plus-devkit"
+$pkg_origin="chef"
+$pkg_version="3.3.1"
+$pkg_revision="1"
+$pkg_maintainer="maintainers@chef.io"
+$pkg_license=@("Apache-2.0")
+$pkg_source="https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-${pkg_version}-${pkg_revision}/rubyinstaller-devkit-${pkg_version}-${pkg_revision}-x64.exe"
+$pkg_shasum = "dc590fb3d1c4254e7d33179bb84df378ead943fece2159eada5f3582bf643cc3"
+$pkg_bin_dirs=@(
+    "bin"
+    "/msys64/ucrt64/bin"
+    "/msys64/usr/bin"
+)
+$ruby_abi_version = [RegEx]::Replace($pkg_version, "\.\d+$", ".0")
+
+function Invoke-SetupEnvironment {
+    Push-RuntimeEnv -IsPath "GEM_PATH" "$pkg_prefix/lib/ruby/gems/$ruby_abi_version"
+}
+
+function Invoke-Unpack {
+    Write-BuildLine "Unpacking $pkg_filename"
+    Start-Process "$HAB_CACHE_SRC_PATH/$pkg_filename" -Wait -ArgumentList "/SP- /NORESTART /VERYSILENT /SUPPRESSMSGBOXES /NOPATH /DIR=$HAB_CACHE_SRC_PATH/$pkg_dirname"
+}
+
+function Invoke-Build {
+    Write-BuildLine "** Launch msys2 once in order to initialize the install"
+    Invoke-Expression -Command "$HAB_CACHE_SRC_PATH/$pkg_dirname/msys64/msys2_shell.cmd -defterm -no-start -c exit" -Verbose
+    # The path separator in the -ILike value below must be a backslash for it will match properly
+    Get-Process | Where-Object Path -ILike "$HAB_CACHE_SRC_PATH\$pkg_dirname\*" | Stop-Process -Force
+}
+
+function Invoke-Install {
+    Write-BuildLine "** Copying files to the package location"
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/*" "$pkg_prefix" -Recurse -Force
+
+    Write-BuildLine "** Include git because why not at this point."
+    Invoke-Expression -Command "$pkg_prefix/bin/ridk.cmd exec pacman -S --noconfirm git" -Verbose
+}
+
+function Invoke-After {
+    Write-BuildLine "** Clean-up unnecessary cached items"
+    Get-ChildItem $pkg_prefix/lib/ruby/gems/$ruby_abi_version/gems -Filter "spec" -Recurse | Remove-Item -Recurse -Force
+    Get-ChildItem $pkg_prefix/lib/ruby/gems/$ruby_abi_version/cache -Recurse | Remove-Item -Recurse -Force
+    Get-ChildItem $pkg_prefix -Filter "unins000.*" | Remove-Item -Recurse -Force
+    Get-ChildItem $pkg_prefix -Filter "share" | Remove-Item -Recurse -Force
+}
+
+function Invoke-End {
+    Write-BuildLine "** Remove RubyInstaller installer from system state"
+    Start-Process "$HAB_CACHE_SRC_PATH/$pkg_dirname/unins000.exe" -Wait -ArgumentList "/SILENT /NORESTART"
+}

--- a/ruby33-plus-devkit/tests/test.pester.ps1
+++ b/ruby33-plus-devkit/tests/test.pester.ps1
@@ -1,0 +1,44 @@
+param(
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows-default/1.0.0/20190812103929")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+
+Describe "ruby33-plus-devkit" {
+    Context "ruby" {
+        It "is an executable" {
+            hab pkg exec $PackageIdentifier ruby.exe -v
+            $? | Should be $true
+        }
+
+        It "is the expected version" {
+            $version_output = (hab pkg exec $PackageIdentifier ruby.exe -v | Out-String)
+            $version_output | Should MatchExactly "ruby ${PackageVersion}"
+        }
+    }
+
+    Context "gem" {
+        It "is an executable" {
+            hab pkg exec $PackageIdentifier gem.cmd -v
+            $? | Should be $true
+        }
+    }
+
+    Context "bundle" {
+        It "is an executable" {
+            hab pkg exec $PackageIdentifier bundle.cmd -v
+            $? | Should be $true
+        }
+    }
+
+    Context "setup environment paths" {
+        $PackagePath = (hab pkg path $PackageIdentifier)
+        It "pushes its gems onto GEM_PATH" {
+            "${PackagePath}/RUNTIME_ENVIRONMENT" | Should ContainExactly "GEM_PATH"
+        }
+        It "does not include build studio kruft in paths" {
+            "${PackagePath}/RUNTIME_ENVIRONMENT" | Should not ContainExactly "\\hab\\studios"
+        }
+    }
+}

--- a/ruby33-plus-devkit/tests/test.ps1
+++ b/ruby33-plus-devkit/tests/test.ps1
@@ -1,0 +1,19 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows/1.0.0/20190812103929")
+)
+
+# ensure Pester is available for test use
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+Write-Host "--- :fire: Smoky Pestering"
+# Pester the Package
+$__dir = (Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -Strict -PassThru -Script @{
+    Path       = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier = $PackageIdentifier }
+}
+if ($test_result.FailedCount -ne 0) { Exit $test_result.FailedCount }


### PR DESCRIPTION
ruby33-plus-devkit added for Inspec for Windows platform.
https://chefio.atlassian.net/browse/CHEF-11397

## Description
ruby33-plus-devkit added for Inspec[CHEF-11397]

## Related Issue
https://chefio.atlassian.net/browse/CHEF-11397

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have run the pre-merge tests locally and they pass.
- [ x] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
