### PR TITLE
Bumping ruby31-plus-devkit from 3.1.2 to 3.1.6 for LTS-2024 and stable channel [CHEF-15295]

### DIFF
--- a/ruby31-plus-devkit/plan.ps1
+++ b/ruby31-plus-devkit/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="ruby31-plus-devkit"
 $pkg_origin="chef"
-$pkg_version="3.1.2"
+$pkg_version="3.1.6"
 $pkg_revision="1"
 $pkg_maintainer="maintainers@chef.io"
 $pkg_license=@("Apache-2.0")
 $pkg_source="https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-${pkg_version}-${pkg_revision}/rubyinstaller-devkit-${pkg_version}-${pkg_revision}-x64.exe"
-$pkg_shasum = "5f0fd4a206b164a627c46e619d2babbcafb0ed4bc3e409267b9a73b6c58bdec1"
+$pkg_shasum = "42f71849f0ae053df8d40182e00ee82a98ac5faa69d815fa850566f2d3711174"
 $pkg_bin_dirs=@(
     "bin"
     "/msys64/ucrt64/bin"


### PR DESCRIPTION
https://chefio.atlassian.net/browse/CHEF-15295



## Description
Bump ruby31-plus-devkit to 3.1.6 for LTS-2024 and stable channel.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
