### PR TITLE
ruby31-plus-devkit bumped to 3.1.7

### DIFF
--- a/ruby31-plus-devkit/plan.ps1
+++ b/ruby31-plus-devkit/plan.ps1
@@ -1,11 +1,11 @@
 $pkg_name="ruby31-plus-devkit"
 $pkg_origin="chef"
-$pkg_version="3.1.6"
+$pkg_version="3.1.7"
 $pkg_revision="1"
 $pkg_maintainer="maintainers@chef.io"
 $pkg_license=@("Apache-2.0")
 $pkg_source="https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-${pkg_version}-${pkg_revision}/rubyinstaller-devkit-${pkg_version}-${pkg_revision}-x64.exe"
-$pkg_shasum = "42f71849f0ae053df8d40182e00ee82a98ac5faa69d815fa850566f2d3711174"
+$pkg_shasum = "c643bf00680aa21f20b34587aa0613e9970d9b63adaef2c0228925a7f9cdfc7a"
 $pkg_bin_dirs=@(
     "bin"
     "/msys64/ucrt64/bin"


### PR DESCRIPTION
ruby31-plus-devkit bumped to 3.1.7 from 3.1.6

https://progresssoftware.atlassian.net/browse/CHEF-23720

## Description
ruby31-plus-devkit bumped to 3.1.7

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
